### PR TITLE
Support custom auth header and user_or_create_function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,9 @@ Add the following lines to your Django settings.py file:
 
     COGNITO_AWS_REGION = '<aws region>' # 'eu-central-1'
     COGNITO_USER_POOL = '<user pool>'   # 'eu-central-1_xYzaq'
-    COGNITO_AUDIENCE = '<client id>'    
+    COGNITO_AUDIENCE = '<client id>'    # the App Client Id in your AWS Cognito console
+    COGNITO_GET_USER_OR_CREATE_FUNCTION = 'USER_MODEL.get_or_create_for_cognito' # your custom get user function name, it will create a new user if it does not exist
+    COGNITO_AUTH_HEADER = 'bearer'      # your custom token header, like 'bearer xxxx.xxxxxxxx.xxxx'
 
 Also update the rest framework settings to use the correct authentication backend:
 
@@ -45,4 +47,6 @@ Also update the rest framework settings to use the correct authentication backen
            ...
         ],
         ...
-     }
+    }
+
+And for your application send the request, just set the request header's Authorization property to `bearer xxxx.xxxxxxxx.xxxx`, the `bearer` is what you set in setting.py COGNITO_AUTH_HEADER.

--- a/README.rst
+++ b/README.rst
@@ -49,4 +49,9 @@ Also update the rest framework settings to use the correct authentication backen
         ...
     }
 
-And for your application send the request, just set the request header's Authorization property to `bearer xxxx.xxxxxxxx.xxxx`, the `bearer` is what you set in setting.py COGNITO_AUTH_HEADER.
+And for your application send the request, just set the request header's Authorization property as this:
+
+.. code-block:: python
+    "bearer xxxx.xxxxxxxx.xxxx"
+
+The `bearer` is what you set in setting.py COGNITO_AUTH_HEADER.

--- a/src/django_cognito_jwt/backend.py
+++ b/src/django_cognito_jwt/backend.py
@@ -38,12 +38,15 @@ class JSONWebTokenAuthentication(BaseAuthentication):
         except TokenError:
             raise exceptions.AuthenticationFailed()
 
-        user = USER_MODEL.objects.get_or_create_for_cognito(jwt_payload)
+        get_or_create_for_cognito_code = '{function_name}(jwt_payload, request)'.format(
+            function_name=settings.COGNITO_GET_USER_OR_CREATE_FUNCTION, jwt_payload=jwt_payload, request=request)
+
+        user = eval(get_or_create_for_cognito_code)
         return (user, jwt_token)
 
     def get_jwt_token(self, request):
         auth = get_authorization_header(request).split()
-        if not auth or smart_text(auth[0].lower()) != 'bearer':
+        if not auth or smart_text(auth[0].lower()) != settings.COGNITO_AUTH_HEADER:
             return None
 
         if len(auth) == 1:


### PR DESCRIPTION
It is not everyone will write their own UserManager I think (also am I), so it is possible to support user to change their custom user_or_create_function and auth header.

Add:
* custom user_or_create_function support
* custom auth header support
Optimize:
* the README document content, user can easy to use this tool