### PR TITLE
Return 401 response for failed authentication attempts.

### DIFF
--- a/src/django_cognito_jwt/backend.py
+++ b/src/django_cognito_jwt/backend.py
@@ -55,3 +55,10 @@ class JSONWebTokenAuthentication(BaseAuthentication):
             raise exceptions.AuthenticationFailed(msg)
 
         return auth[1]
+
+    def authenticate_header(self, request):
+        """
+        Method required by the DRF in order to return 401 responses for authentication failures, instead of 403.
+        More details in https://www.django-rest-framework.org/api-guide/authentication/#custom-authentication.
+        """
+        return 'Bearer: api'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,8 @@ def pytest_configure():
                 'ENGINE': 'django.db.backends.sqlite3',
                 'NAME': 'db.sqlite',
             },
-        }
+        },
+        ROOT_URLCONF='urls',
     )
 
 def _private_to_public_key(private_key):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2,7 +2,9 @@
 import pytest
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.test import Client
 from rest_framework.exceptions import AuthenticationFailed
+from rest_framework import status
 
 from django_cognito_jwt import backend
 from utils import create_jwt_token
@@ -78,3 +80,10 @@ def test_authenticate_error_spaces(rf):
 
     with pytest.raises(AuthenticationFailed):
         auth.authenticate(request)
+
+
+def test_authenticate_error_response_code():
+    client = Client()
+    resp = client.get('/', HTTP_AUTHORIZATION=b'bearer random iets')
+
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,16 @@
+from django.conf.urls import url
+
+from django_cognito_jwt import JSONWebTokenAuthentication
+from rest_framework.decorators import api_view, authentication_classes
+from rest_framework.response import Response
+
+
+@api_view(http_method_names=['GET'])
+@authentication_classes((JSONWebTokenAuthentication,))
+def sample_view(request):
+    return Response({'hello': 'world'})
+
+
+urlpatterns = [
+    url(r'^$', sample_view, name='sample_view'),
+]


### PR DESCRIPTION
As per the [docucumentation](https://www.django-rest-framework.org/api-guide/authentication/#custom-authentication), the authentication backend has to define an `authenticate_header` method for it to return 401 response for failed authentication attempts. Otherwise a 403 response is returned.