### PR TITLE
 Add setting that enables caching the Cognito public keys using Django CACHES

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,13 +26,22 @@ Installation
 Usage
 =====
 
-Add the following lines to your Django settings.py file:
+Add the following lines to your Django ``settings.py`` file:
 
 .. code-block:: python
 
     COGNITO_AWS_REGION = '<aws region>' # 'eu-central-1'
-    COGNITO_USER_POOL = '<user pool>'   # 'eu-central-1_xYzaq'
-    COGNITO_AUDIENCE = '<client id>'    
+    COGNITO_USER_POOL = '<user pool>'   # 'eu-central-1_xYzaq'
+    COGNITO_AUDIENCE = '<client id>'
+
+(Optional) If you want to cache the Cognito public keys between requests you can
+enable the ``COGNITO_PUBLIC_KEYS_CACHING_ENABLED`` setting (it only works if you
+have the Django ``CACHES`` setup to anything other than the dummy backend).
+
+.. code-block:: python
+
+    COGNITO_PUBLIC_KEYS_CACHING_ENABLED = True
+    COGNITO_PUBLIC_KEYS_CACHING_TIMEOUT = 60*60*24  # 24h caching, default is 300s
 
 Also update the rest framework settings to use the correct authentication backend:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -349,4 +349,3 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #
 # texinfo_no_detailmenu = False
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ testpaths = tests
 universal=1
 
 [flake8]
-max-line-length = 99
+max-line-length = 119
 
 [bumpversion]
 current_version = 0.0.1

--- a/src/django_cognito_jwt/__init__.py
+++ b/src/django_cognito_jwt/__init__.py
@@ -1,3 +1,3 @@
 __version__ = '0.0.1'
 
-from .backend import JSONWebTokenAuthentication
+from .backend import JSONWebTokenAuthentication  # noqa

--- a/src/django_cognito_jwt/validator.py
+++ b/src/django_cognito_jwt/validator.py
@@ -3,6 +3,8 @@ import jwt
 import requests
 from jwt.algorithms import RSAAlgorithm
 
+from django.conf import settings
+from django.core.cache import cache
 from django.utils.functional import cached_property
 
 
@@ -34,7 +36,17 @@ class TokenValidator:
         except jwt.DecodeError as exc:
             raise TokenError(str(exc))
 
-        jwk_data = self._json_web_keys.get(headers['kid'])
+        if getattr(settings, 'COGNITO_PUBLIC_KEYS_CACHING_ENABLED', False):
+            cached_jwk_data = cache.get(headers['kid'])
+            if cached_jwk_data:
+                jwk_data = cached_jwk_data
+            else:
+                jwk_data = self._json_web_keys.get(headers['kid'])
+                timeout = getattr(settings, 'COGNITO_PUBLIC_KEYS_CACHING_TIMEOUT', 300)
+                cache.set(headers['kid'], jwk_data, timeout=timeout)
+        else:
+            jwk_data = self._json_web_keys.get(headers['kid'])
+
         if jwk_data:
             return RSAAlgorithm.from_jwk(jwk_data)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ def pytest_configure():
         ROOT_URLCONF='urls',
     )
 
+
 def _private_to_public_key(private_key):
     data = copy.deepcopy(private_key)
     del data['d']
@@ -61,6 +62,7 @@ def jwk_private_key_one():
             "qsjkpRBst1DG9094K_PRFcEszIlwt1NUHDMGQV1gHg3zebXxKumQ"
         )
     }
+
 
 @pytest.fixture()
 def jwk_public_key_one(jwk_private_key_one):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -48,8 +48,8 @@ def test_validate_token_error_aud(cognito_well_known_keys, jwk_private_key_one):
     (False, 2),
     (True, 1),
 ])
-def test_validate_token_cache_not_enabled(
-        cognito_well_known_keys, jwk_private_key_one, settings, responses, is_cache_enabled, responses_calls):
+def test_validate_token_caching(cognito_well_known_keys, jwk_private_key_one, settings, responses, is_cache_enabled,
+                                responses_calls):
     if is_cache_enabled is not None:
         settings.COGNITO_PUBLIC_KEYS_CACHING_ENABLED = is_cache_enabled
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -41,3 +41,29 @@ def test_validate_token_error_aud(cognito_well_known_keys, jwk_private_key_one):
 
     with pytest.raises(validator.TokenError):
         auth.validate(token)
+
+
+@pytest.mark.parametrize("is_cache_enabled,responses_calls", [
+    (None, 2),
+    (False, 2),
+    (True, 1),
+])
+def test_validate_token_cache_not_enabled(
+        cognito_well_known_keys, jwk_private_key_one, settings, responses, is_cache_enabled, responses_calls):
+    if is_cache_enabled is not None:
+        settings.COGNITO_PUBLIC_KEYS_CACHING_ENABLED = is_cache_enabled
+
+    token = create_jwt_token(
+        jwk_private_key_one,
+        {
+            'iss': 'https://cognito-idp.eu-central-1.amazonaws.com/bla',
+            'aud': 'my-audience',
+            'sub': 'username',
+        })
+    auth = validator.TokenValidator('eu-central-1', 'bla', 'my-audience')
+    auth.validate(token)
+    assert len(responses.calls) == 1
+
+    auth_again = validator.TokenValidator('eu-central-1', 'bla', 'my-audience')
+    auth_again.validate(token)
+    assert len(responses.calls) == responses_calls


### PR DESCRIPTION
Falls back on the current behaviour if the setting `COGNITO_PUBLIC_KEYS_CACHING_ENABLED` is not explicitly set to `True` in the Django settings file of the project.

Support for custom cache timeout by setting the value of `COGNITO_PUBLIC_KEYS_CACHING_TIMEOUT` in Django settings.