### PR TITLE
Adding request to user method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,3 +71,10 @@ you can use the ``COGNITO_USER_MODEL`` setting.
 .. code-block:: python
 
 	COGNITO_USER_MODEL = "myproject.AppUser"
+
+(Optional) If you want to send the request object to the custom user model then set the ``COGNITO_USER_MODEL_ADD_REQUEST_OBJ`` to true.
+
+.. code-block:: python
+
+    COGNITO_USER_MODEL_ADD_REQUEST_OBJ = True
+

--- a/src/django_cognito_jwt/backend.py
+++ b/src/django_cognito_jwt/backend.py
@@ -28,8 +28,12 @@ class JSONWebTokenAuthentication(BaseAuthentication):
         except TokenError:
             raise exceptions.AuthenticationFailed()
 
+        add_request = getattr(settings, "COGNITO_USER_MODEL_ADD_REQUEST_OBJ", False)
         USER_MODEL = self.get_user_model()
-        user = USER_MODEL.objects.get_or_create_for_cognito(jwt_payload)
+        if add_request:
+            user = USER_MODEL.objects.get_or_create_for_cognito(jwt_payload, request)
+        else:
+            user = USER_MODEL.objects.get_or_create_for_cognito(jwt_payload)
         return (user, jwt_token)
 
     def get_user_model(self):


### PR DESCRIPTION
Hi everyone,  - I needed a method to add the request object to the call to get_or_create_for_cognito. I saw in one of the other pull requests this was also added.

I've created a crude system to do this, now I can receive from this library with
 def get_or_create_for_cognito(self, jwt_payload, request): 
in my manager model. 

I am open to helping any suggestions to doing this in a better/cleaner way. (I'm also quite new to python packaging and its tooling..)