### PR TITLE
Adding the option to use a custom user manager to retrieve the user f…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ docs_require = [
 ]
 
 tests_require = [
-    'coverage==.4.4.2',
+    'coverage==4.4.2',
     'pytest==3.3.2',
     'pytest-cov==2.5.1',
     'pytest-django==3.1.2',

--- a/src/django_cognito_jwt/backend.py
+++ b/src/django_cognito_jwt/backend.py
@@ -6,6 +6,8 @@ from django.utils.encoding import smart_text
 from django.utils.translation import ugettext as _
 from rest_framework import exceptions
 from rest_framework.authentication import BaseAuthentication, get_authorization_header
+from django.utils.module_loading import import_string
+
 
 from django_cognito_jwt.validator import TokenError, TokenValidator
 
@@ -28,9 +30,20 @@ class JSONWebTokenAuthentication(BaseAuthentication):
         except TokenError:
             raise exceptions.AuthenticationFailed()
 
-        USER_MODEL = self.get_user_model()
-        user = USER_MODEL.objects.get_or_create_for_cognito(jwt_payload)
+        custom_user_manager = self.get_custom_user_manager()
+        if custom_user_manager:
+            user = custom_user_manager.get_or_create_for_cognito(jwt_payload)
+        else:
+            USER_MODEL = self.get_user_model()
+            user = USER_MODEL.objects.get_or_create_for_cognito(jwt_payload)
         return (user, jwt_token)
+
+    def get_custom_user_manager(self):
+        result = None
+        custom_user_manager_path = getattr(settings, "COGNITO_USER_MANAGER", False)
+        if(custom_user_manager_path):
+            result = import_string(custom_user_manager_path)()
+        return result
 
     def get_user_model(self):
         user_model = getattr(settings, "COGNITO_USER_MODEL", settings.AUTH_USER_MODEL)


### PR DESCRIPTION
 Adding the option to use a custom user manager to retrieve the user from cognito without having to create a custom user model
To use that feature, all you have to do is to configure the variable
COGNITO_USER_MANAGER=cognito_users.models.CognitoManager

Then you can define you own manager:
class CognitoManager(BaseUserManager):
    def get_or_create_for_cognito(self, jwt_payload):
        username = jwt_payload['cognito:username']
        email = jwt_payload['email']
        groups = jwt_payload['cognito:groups']
        try:
            user = get_user_model().objects.get(username=username)
        except:
            password = get_user_model().objects.make_random_password()
            user = get_user_model().objects.create_user(username, email, password)
        if 'superusers' in groups:
            user.is_superuser = True
            user.is_active = True
            user.is_staff = True
            user.save()
        return user

In that way you don't need to customize your COGNITO_USER_MODEL which could be hard on an already running project.

Please, tell me if you would be interested in accepting a feature like that. If you are interested I can add documentation for it