### PR TITLE
Update tests and documentation to show that multiple audiences are supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 /docs/_build/
 /htmlcov/
 
+env/
 
 # Editors
 .idea/
+.vscode/

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Add the following lines to your Django ``settings.py`` file:
 
     COGNITO_AWS_REGION = '<aws region>' # 'eu-central-1'
     COGNITO_USER_POOL = '<user pool>'   # 'eu-central-1_xYzaq'
-    COGNITO_AUDIENCE = '<client id>'
+    COGNITO_AUDIENCE = '<client id>'    # or = ['<client id 1>', 'client id 2', ...]
 
 (Optional) If you want to cache the Cognito public keys between requests you can
 enable the ``COGNITO_PUBLIC_KEYS_CACHING_ENABLED`` setting (it only works if you

--- a/src/django_cognito_jwt/validator.py
+++ b/src/django_cognito_jwt/validator.py
@@ -16,6 +16,7 @@ class TokenValidator:
     def __init__(self, aws_region, aws_user_pool, audience):
         self.aws_region = aws_region
         self.aws_user_pool = aws_user_pool
+        #should be either a single audience string, or an array of audience strings
         self.audience = audience
 
     @cached_property

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -17,6 +17,19 @@ def test_validate_token(cognito_well_known_keys, jwk_private_key_one):
     auth.validate(token)
 
 
+def test_validate_token_multiple_aud(cognito_well_known_keys, jwk_private_key_one):
+    token = create_jwt_token(
+        jwk_private_key_one,
+        {
+            "iss": "https://cognito-idp.eu-central-1.amazonaws.com/bla",
+            "aud": "my-audience-2",
+            "sub": "username",
+        },
+    )
+    auth = validator.TokenValidator("eu-central-1", "bla", ["my-audience", "my-audience-2", "my-audience-3"])
+    auth.validate(token)
+
+
 def test_validate_token_error_key(cognito_well_known_keys, jwk_private_key_two):
     token = create_jwt_token(
         jwk_private_key_two,
@@ -41,6 +54,21 @@ def test_validate_token_error_aud(cognito_well_known_keys, jwk_private_key_one):
         },
     )
     auth = validator.TokenValidator("eu-central-1", "bla", "my-audience")
+
+    with pytest.raises(validator.TokenError):
+        auth.validate(token)
+
+
+def test_validate_token_multiple_aud_error_aud(cognito_well_known_keys, jwk_private_key_one):
+    token = create_jwt_token(
+        jwk_private_key_one,
+        {
+            "iss": "https://cognito-idp.eu-central-1.amazonaws.com/bla",
+            "aud": "other-audience",
+            "sub": "username",
+        },
+    )
+    auth = validator.TokenValidator("eu-central-1", "bla", ["my-audience", "my-audience-2", "my-audience-3"])
 
     with pytest.raises(validator.TokenError):
         auth.validate(token)


### PR DESCRIPTION
One of the issues that seems to have popped up a few times here is that there is no clear way to support multiple audiences with the TokenValidator. This can be a problem when you have a User Pool with more than one client id, which is common for projects that have a REST API for external use.

I had intended to write a new feature branch that would allow for the support of multiple audiences, but as it turns out, there already is support, it's just not documented. So I've added a couple of comments and tests to make it more clear that this is the case.