### PR TITLE
Make token validation compatible with AccessToken where "aud" claim is not provided

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -46,6 +46,19 @@ def test_validate_token_error_aud(cognito_well_known_keys, jwk_private_key_one):
         auth.validate(token)
 
 
+def test_validate_token_missing_aud(cognito_well_known_keys, jwk_private_key_one):
+    token = create_jwt_token(
+        jwk_private_key_one,
+        {
+            "iss": "https://cognito-idp.eu-central-1.amazonaws.com/bla",
+            # missing aud
+            "sub": "username",
+        },
+    )
+    auth = validator.TokenValidator("eu-central-1", "bla", "my-audience")
+    auth.validate(token)
+
+
 @pytest.mark.parametrize(
     "is_cache_enabled,responses_calls", [(None, 2), (False, 2), (True, 1)]
 )


### PR DESCRIPTION
As described here:
https://github.com/labd/django-cognito-jwt/issues/22

The AccessToken validation is currently broken because the library is mandatorily checking the audience (aud) claim, which is not included in the AccessToken payload.

These few changes should detect it dynamically and check "aud" claim only when it is included in the token.