### PR TITLE
Upgrade/pyjwt support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ tests_require = [
 
 setup(
     name="django-cognito-jwt",
-    version="0.0.3",
+    version="0.0.4",
     description="Django backends for AWS Cognito JWT",
     long_description=open("README.rst", "r").read(),
     url="https://github.com/LabD/django-cognito-jwt",

--- a/src/django_cognito_jwt/validator.py
+++ b/src/django_cognito_jwt/validator.py
@@ -65,6 +65,6 @@ class TokenValidator:
                 issuer=self.pool_url,
                 algorithms=["RS256"],
             )
-        except (jwt.InvalidTokenError, jwt.ExpiredSignature, jwt.DecodeError) as exc:
+        except (jwt.InvalidTokenError, jwt.ExpiredSignatureError, jwt.DecodeError) as exc:
             raise TokenError(str(exc))
         return jwt_data

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -36,12 +36,13 @@ def test_authenticate_valid(
         USER_MODEL.objects, "get_or_create_for_cognito", func, raising=False
     )
 
-    request = rf.get("/", HTTP_AUTHORIZATION=b"bearer %s" % token)
+    authorization_header = f"bearer {token}"
+    request = rf.get("/", HTTP_AUTHORIZATION=authorization_header)
     auth = backend.JSONWebTokenAuthentication()
     user, auth_token = auth.authenticate(request)
     assert user
     assert user.username == "username"
-    assert auth_token == token
+    assert auth_token == token.encode('utf8')
 
 
 def test_authenticate_invalid(rf, cognito_well_known_keys, jwk_private_key_two):
@@ -54,7 +55,8 @@ def test_authenticate_invalid(rf, cognito_well_known_keys, jwk_private_key_two):
         },
     )
 
-    request = rf.get("/", HTTP_AUTHORIZATION=b"bearer %s" % token)
+    authorization_header = f"bearer {token}"
+    request = rf.get("/", HTTP_AUTHORIZATION=authorization_header)
     auth = backend.JSONWebTokenAuthentication()
 
     with pytest.raises(AuthenticationFailed):


### PR DESCRIPTION
fix update in pyjwt where `jwt.ExpiredSignature` was changed to `jwt.ExpiredSignatureError`.

```
    jwt_payload = token_validator.validate(jwt_token)
  File ".../site-packages/django_cognito_jwt/validator.py", line 68, in validate
    except (jwt.InvalidTokenError, jwt.ExpiredSignature, jwt.DecodeError) as exc:
rest_framework.request.WrappedAttributeError: module 'jwt' has no attribute 'ExpiredSignature'

```