### PR TITLE
fixed invalid jwt import

### DIFF
--- a/src/django_cognito_jwt/validator.py
+++ b/src/django_cognito_jwt/validator.py
@@ -65,6 +65,6 @@ class TokenValidator:
                 issuer=self.pool_url,
                 algorithms=["RS256"],
             )
-        except (jwt.InvalidTokenError, jwt.ExpiredSignature, jwt.DecodeError) as exc:
+        except (jwt.InvalidTokenError, jwt.ExpiredSignatureError, jwt.DecodeError) as exc:
             raise TokenError(str(exc))
         return jwt_data


### PR DESCRIPTION
Trying to validate an expired token did not raise a TokenError. 
Instead there would be an invalid import error:
 File ".../django_cognito_jwt/validator.py", line 68, in validate
    except (jwt.InvalidTokenError, jwt.ExpiredSignature, jwt.DecodeError) as exc:
AttributeError: module 'jwt' has no attribute 'ExpiredSignature'

As can be seen here, the jwt package actually exports ExpiredSignatureError, not ExpiredSignature
ctrl+f "expired" : https://pyjwt.readthedocs.io/en/latest/usage.html