### PR TITLE
fix pyjwt version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ install_requires = [
     "Django>=1.11",
     "cryptography",
     "djangorestframework",
-    "pyjwt",
+    "pyjwt==1.7.1",
     "requests",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ install_requires = [
     "Django>=1.11",
     "cryptography",
     "djangorestframework",
-    "pyjwt==1.7.1",
+    "pyjwt",
     "requests",
 ]
 

--- a/src/django_cognito_jwt/validator.py
+++ b/src/django_cognito_jwt/validator.py
@@ -65,6 +65,6 @@ class TokenValidator:
                 issuer=self.pool_url,
                 algorithms=["RS256"],
             )
-        except (jwt.InvalidTokenError, jwt.ExpiredSignature, jwt.DecodeError) as exc:
+        except (jwt.InvalidTokenError, jwt.ExpiredSignatureError, jwt.DecodeError) as exc:
             raise TokenError(str(exc))
         return jwt_data

--- a/src/django_cognito_jwt/validator.py
+++ b/src/django_cognito_jwt/validator.py
@@ -65,6 +65,10 @@ class TokenValidator:
                 issuer=self.pool_url,
                 algorithms=["RS256"],
             )
-        except (jwt.InvalidTokenError, jwt.ExpiredSignatureError, jwt.DecodeError) as exc:
+        except (
+            jwt.InvalidTokenError,
+            jwt.ExpiredSignatureError,
+            jwt.DecodeError,
+        ) as exc:
             raise TokenError(str(exc))
         return jwt_data

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -36,12 +36,12 @@ def test_authenticate_valid(
         USER_MODEL.objects, "get_or_create_for_cognito", func, raising=False
     )
 
-    request = rf.get("/", HTTP_AUTHORIZATION=b"bearer %s" % token)
+    request = rf.get("/", HTTP_AUTHORIZATION=b"bearer %s" % token.encode("UTF-8"))
     auth = backend.JSONWebTokenAuthentication()
     user, auth_token = auth.authenticate(request)
     assert user
     assert user.username == "username"
-    assert auth_token == token
+    assert auth_token == token.encode("UTF-8")
 
 
 def test_authenticate_invalid(rf, cognito_well_known_keys, jwk_private_key_two):
@@ -54,7 +54,7 @@ def test_authenticate_invalid(rf, cognito_well_known_keys, jwk_private_key_two):
         },
     )
 
-    request = rf.get("/", HTTP_AUTHORIZATION=b"bearer %s" % token)
+    request = rf.get("/", HTTP_AUTHORIZATION=b"bearer %s" % token.encode("UTF-8"))
     auth = backend.JSONWebTokenAuthentication()
 
     with pytest.raises(AuthenticationFailed):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -36,12 +36,12 @@ def test_authenticate_valid(
         USER_MODEL.objects, "get_or_create_for_cognito", func, raising=False
     )
 
-    request = rf.get("/", HTTP_AUTHORIZATION=b"bearer %s" % token.encode("UTF-8"))
+    request = rf.get("/", HTTP_AUTHORIZATION=b"bearer %s" % token.encode("utf8"))
     auth = backend.JSONWebTokenAuthentication()
     user, auth_token = auth.authenticate(request)
     assert user
     assert user.username == "username"
-    assert auth_token == token.encode("UTF-8")
+    assert auth_token == token.encode("utf8")
 
 
 def test_authenticate_invalid(rf, cognito_well_known_keys, jwk_private_key_two):
@@ -54,7 +54,7 @@ def test_authenticate_invalid(rf, cognito_well_known_keys, jwk_private_key_two):
         },
     )
 
-    request = rf.get("/", HTTP_AUTHORIZATION=b"bearer %s" % token.encode("UTF-8"))
+    request = rf.get("/", HTTP_AUTHORIZATION=b"bearer %s" % token.encode("utf8"))
     auth = backend.JSONWebTokenAuthentication()
 
     with pytest.raises(AuthenticationFailed):


### PR DESCRIPTION
ref https://github.com/flavors/django-graphql-jwt/issues/242
ref https://stackoverflow.com/questions/65757394/module-jwt-has-no-attribute-expiredsignature

![image](https://user-images.githubusercontent.com/9539763/145616394-b6c53ec5-87fd-44ad-b1c9-fd0730063d06.png)

@mikedebock the wrong pyjwt version was the only issue I found breaking the build, see ref above (it's also unrelated to my changes)

related PR https://github.com/labd/django-cognito-jwt/pull/40