### PR TITLE
Added Exception Handeling On Cognito Validation Request

### DIFF
--- a/src/django_cognito_jwt/validator.py
+++ b/src/django_cognito_jwt/validator.py
@@ -6,6 +6,9 @@ from django.conf import settings
 from django.core.cache import cache
 from django.utils.functional import cached_property
 from jwt.algorithms import RSAAlgorithm
+from logging import getLogger
+
+logger = getLogger("django.request")
 
 
 class TokenError(Exception):
@@ -32,7 +35,8 @@ class TokenValidator:
             response.raise_for_status()
             json_data = response.json()
             return {item["kid"]: json.dumps(item) for item in json_data["keys"]}
-        except (ConnectionError, Exception):
+        except (ConnectionError, Exception) as e:
+            logger.exception(e)
             return {}
 
     def _get_public_key(self, token):

--- a/src/django_cognito_jwt/validator.py
+++ b/src/django_cognito_jwt/validator.py
@@ -27,10 +27,13 @@ class TokenValidator:
 
     @cached_property
     def _json_web_keys(self):
-        response = requests.get(self.pool_url + "/.well-known/jwks.json")
-        response.raise_for_status()
-        json_data = response.json()
-        return {item["kid"]: json.dumps(item) for item in json_data["keys"]}
+        try:
+            response = requests.get(self.pool_url + "/.well-known/jwks.json")
+            response.raise_for_status()
+            json_data = response.json()
+            return {item["kid"]: json.dumps(item) for item in json_data["keys"]}
+        except (ConnectionError, Exception):
+            return {}
 
     def _get_public_key(self, token):
         try:


### PR DESCRIPTION
### Fix Connection Error

Exception is not being handled when requesting `.well-known/jwks.json` which makes django server return  status code 500. I believe authentication backends should be robust and should handle these sort of issue and flag the incoming request as unauthorized. 