### PR TITLE
Add option to choose between id token and access token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .cache
 .python-version
 .venv
+venv/
 .idea/
 
 /build/
@@ -17,3 +18,4 @@
 
 # Editors
 .idea/
+.vscode/

--- a/README.rst
+++ b/README.rst
@@ -77,4 +77,12 @@ The library by default uses id token. To use access token, add the following lin
 
 .. code-block:: python
 
-	COGNITO_TOKEN_TYPE = "access"  # '{'id', 'access'} Default: 'id'
+	COGNITO_TOKEN_TYPE = "access"  # {'id', 'access'}, default 'id'
+
+
+As the payload of access token only contains basic user info, we could obtain further info from the `UserInfo endpoint`.
+You need to specify the Cognito domain in the ``settings.py`` file to obtain the user info from the endpoint, as follows:
+
+.. code-block:: python
+
+	COGNITO_DOMAIN = "your-user-pool-domain"  # eg, exampledomain.auth.ap-southeast-1.amazoncognito.com

--- a/README.rst
+++ b/README.rst
@@ -72,3 +72,7 @@ you can use the ``COGNITO_USER_MODEL`` setting.
 .. code-block:: python
 
 	COGNITO_USER_MODEL = "myproject.AppUser"
+
+The library by default uses id token. To use access token, add the following lines to your Django ``settings.py`` file:
+.. {'id', 'access'} Default: 'id'
+COGNITO_TOKEN_TYPE = 'access' 

--- a/README.rst
+++ b/README.rst
@@ -74,5 +74,7 @@ you can use the ``COGNITO_USER_MODEL`` setting.
 	COGNITO_USER_MODEL = "myproject.AppUser"
 
 The library by default uses id token. To use access token, add the following lines to your Django ``settings.py`` file:
-.. {'id', 'access'} Default: 'id'
-COGNITO_TOKEN_TYPE = 'access' 
+
+.. code-block:: python
+
+	COGNITO_TOKEN_TYPE = "access"  # '{'id', 'access'} Default: 'id'

--- a/src/django_cognito_jwt/backend.py
+++ b/src/django_cognito_jwt/backend.py
@@ -58,6 +58,7 @@ class JSONWebTokenAuthentication(BaseAuthentication):
             settings.COGNITO_AWS_REGION,
             settings.COGNITO_USER_POOL,
             settings.COGNITO_AUDIENCE,
+            settings.COGNITO_TOKEN_TYPE,
         )
 
     def authenticate_header(self, request):

--- a/src/django_cognito_jwt/validator.py
+++ b/src/django_cognito_jwt/validator.py
@@ -73,6 +73,11 @@ class TokenValidator:
                 params.update({"audience": self.audience})
 
             jwt_data = jwt.decode(**params)
+            if self.token_type == "access":
+                if "access" not in jwt_data["token_use"]:
+                    raise TokenError("Incorrect token use")
+                if jwt_data["client_id"] not in self.audience:
+                    raise TokenError("Incorrect client_id")
         except (
             jwt.InvalidTokenError,
             jwt.ExpiredSignatureError,


### PR DESCRIPTION
Fixes #22 

User can define to use id token or access token in `settings.py`.
Without defining, it by default take id token.

```python
COGNITO_TOKEN_TYPE = "access"  # '{'id', 'access'} Default: 'id'
```